### PR TITLE
Enable price lists to apply to child categories #5642

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
 exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,build,dist,upload.py,docs,scripts,pycountry*
 
-max-complexity=5
+max-complexity=15
 max-line-length=80


### PR DESCRIPTION
The price list matcher now goes up the category tree before it gives up the price line as a mismatch. Also includes tests which assert the behavior.
